### PR TITLE
Add US 3-star news notifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-# python_test
+# US 3-Star News Notifier
+
+This small application fetches the daily high impact ("3 étoiles") economic news for the United States using the [TradingEconomics API](https://tradingeconomics.com/api/), and displays them in a window. The application is intended to be launched automatically at Windows logon.
+
+## Requirements
+
+- Python 3.8+
+- `requests` library
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the script manually:
+
+```bash
+python fetch_news.py
+```
+
+A small window will appear listing today's high impact US news events.
+
+## Start at Windows logon
+
+To start the application when you sign into Windows:
+
+1. Create a batch file `run_news.bat` with the following content (adjust the Python path if needed):
+
+    ```bat
+    @echo off
+    python "C:\path\to\project\fetch_news.py"
+    ```
+
+2. Press `Win + R`, type `shell:startup` and press Enter. Copy the batch file into the folder that opens. The script will now run automatically whenever you sign in.
+

--- a/fetch_news.py
+++ b/fetch_news.py
@@ -1,0 +1,54 @@
+import datetime
+import requests
+import tkinter as tk
+from tkinter import messagebox
+
+API_URL = "https://api.tradingeconomics.com/calendar/country/united%20states"
+API_AUTH = "guest:guest"
+
+
+def fetch_high_impact_news():
+    today = datetime.date.today().isoformat()
+    params = {
+        "c": API_AUTH,
+        "d1": today,
+        "d2": today,
+        "format": "json",
+    }
+    try:
+        resp = requests.get(API_URL, params=params, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as exc:
+        messagebox.showerror("Network error", f"Could not fetch news: {exc}")
+        return []
+
+    filtered = []
+    for item in data:
+        importance = item.get("Importance")
+        if importance in ("High", "3", 3):
+            filtered.append(item)
+    return filtered
+
+
+def display_news(news_items):
+    root = tk.Tk()
+    root.title("News US - 3 étoiles")
+    if not news_items:
+        label = tk.Label(root, text="Aucune news 3 étoiles trouvée.")
+        label.pack(padx=10, pady=10)
+    else:
+        for item in news_items:
+            date = item.get("Date", "")
+            event = item.get("Event", "")
+            tk.Label(root, text=f"{date} - {event}").pack(anchor="w")
+    root.mainloop()
+
+
+def main():
+    news = fetch_high_impact_news()
+    display_news(news)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
## Summary
- build a small Tkinter app that fetches US high-impact news from the TradingEconomics API
- document how to install and run the tool
- explain how to make it run automatically at Windows startup

## Testing
- `python -m py_compile fetch_news.py`
- `python fetch_news.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6844bf1e1f7c832c9d2b9d90f89f6ba8